### PR TITLE
Style Enqueuing Comment Patch

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -3,7 +3,7 @@
 add_action( 'wp_enqueue_scripts', 'moiraine_child_enqueue_styles' );
 
 /**
- * Enqueue Ollie styles.
+ * Enqueue Moiraine Child styles.
  *
  * @return void
  */


### PR DESCRIPTION
This pull request includes a small change to the `functions.php` file. The change updates the comment to correctly reflect the name of the child theme whose styles are being enqueued.

* [`functions.php`](diffhunk://#diff-01c9525afc2c87cfcb03124117c9d0ebb067029f6c955a607fa0fd4274aca556L6-R6): Updated the comment to change "Ollie" to "Moiraine Child" to accurately describe the enqueued styles.